### PR TITLE
fix: disconnect observer on page leave

### DIFF
--- a/src/hooks/useActiveId.ts
+++ b/src/hooks/useActiveId.ts
@@ -21,11 +21,7 @@ export const useActiveId = (items: Section[]) => {
       observer.observe(document.getElementById(item.id) as Element)
     })
 
-    return () => {
-      items.forEach((item) => {
-        observer.unobserve(document.getElementById(item.id) as Element)
-      })
-    }
+    return () => observer.disconnect()
   }, [items])
 
   return activeId


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR disconnects the observer as a way to clean up everything after the current page is unmounted.