### PR TITLE
add tailwindcss prettier plugin

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "trailingComma": "es5",
   "semi": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "eslint": "^8.22.0",
         "eslint-config-next": "^12.2.5",
         "postcss": "^8.4.16",
+        "prettier": "^2.7.1",
+        "prettier-plugin-tailwindcss": "^0.1.13",
         "tailwindcss": "^3.1.8",
         "typescript": "^4.7.4"
       }
@@ -3262,6 +3264,33 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.13.tgz",
+      "integrity": "sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6250,6 +6279,19 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.13.tgz",
+      "integrity": "sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==",
+      "dev": true,
+      "requires": {}
     },
     "prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "eslint": "^8.22.0",
     "eslint-config-next": "^12.2.5",
     "postcss": "^8.4.16",
+    "prettier": "^2.7.1",
+    "prettier-plugin-tailwindcss": "^0.1.13",
     "tailwindcss": "^3.1.8",
     "typescript": "^4.7.4"
   }

--- a/src/components/Contribution.tsx
+++ b/src/components/Contribution.tsx
@@ -20,16 +20,16 @@ export const Contribution = () => {
     : 'https://github.com/blutui/dev.blutui.com'
 
   return (
-    <div className="border dark:border-gray-700 rounded-lg p-6 max-w-xs">
-      <h2 className="font-semibold tracking-tight text-gray-700 dark:text-gray-200 mb-4">
+    <div className="max-w-xs rounded-lg border p-6 dark:border-gray-700">
+      <h2 className="mb-4 font-semibold tracking-tight text-gray-700 dark:text-gray-200">
         Help us make these docs great!
       </h2>
-      <p className="mb-4 text-zinc-600 dark:text-gray-500 text-sm">
+      <p className="mb-4 text-sm text-zinc-600 dark:text-gray-500">
         All Blutui docs are open source. See something that{"'"}s wrong or
         unclear? Submit a pull request.
       </p>
       <a
-        className="border dark:border-gray-700 px-4 py-2 rounded-md font-semibold text-indigo-600 dark:text-indigo-400 hover:border-gray-300 hover:bg-gray-100 transition"
+        className="rounded-md border px-4 py-2 font-semibold text-indigo-600 transition hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:text-indigo-400"
         href={contributionHref}
       >
         Make a contribution

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,26 +14,26 @@ export const Header = ({ children }: HeaderProps) => {
   const actionKey = useActionKey()
 
   return (
-    <header className="sticky top-0 z-10 flex-none bg-gray-50/70 dark:bg-gray-900/70 backdrop-blur">
+    <header className="sticky top-0 z-10 flex-none bg-gray-50/70 backdrop-blur dark:bg-gray-900/70">
       <div className="mx-auto max-w-8xl">
-        <div className="px-8 flex items-center justify-between h-[3.75rem] space-x-8">
-          <div className="flex items-center flex-shrink-0">
+        <div className="flex h-[3.75rem] items-center justify-between space-x-8 px-8">
+          <div className="flex flex-shrink-0 items-center">
             <Link href="/">
               <a className="w-72">
                 <span className="sr-only">Blutui Developers home page</span>
-                <Logo className="w-auto h-8 mt-1" />
+                <Logo className="mt-1 h-8 w-auto" />
               </a>
             </Link>
-            <span className="hidden lg:block h-6 border-l border-black/10 dark:border-white/10"></span>
+            <span className="hidden h-6 border-l border-black/10 dark:border-white/10 lg:block"></span>
           </div>
           <div className="flex flex-auto items-center space-x-6">
-            <SearchButton className="hidden lg:block text-left text-gray-500 dark:text-gray-400 font-medium tracking-tight px-4 py-1.5 rounded-full bg-black/10 hover:bg-black/20 dark:bg-white/10 dark:hover:bg-white/20 transition">
-              <div className="flex items-center lg:w-80 space-x-3">
+            <SearchButton className="hidden rounded-full bg-black/10 px-4 py-1.5 text-left font-medium tracking-tight text-gray-500 transition hover:bg-black/20 dark:bg-white/10 dark:text-gray-400 dark:hover:bg-white/20 lg:block">
+              <div className="flex items-center space-x-3 lg:w-80">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 20 20"
                   fill="currentColor"
-                  className="w-5 h-5"
+                  className="h-5 w-5"
                 >
                   <path
                     fillRule="evenodd"
@@ -41,9 +41,9 @@ export const Header = ({ children }: HeaderProps) => {
                     clipRule="evenodd"
                   />
                 </svg>
-                <span className="flex-auto block">Quick search...</span>
+                <span className="block flex-auto">Quick search...</span>
                 {actionKey && (
-                  <kbd className="ml-2 text-xs font-sans font-semibold text-gray-600 dark:text-gray-300">
+                  <kbd className="ml-2 font-sans text-xs font-semibold text-gray-600 dark:text-gray-300">
                     <abbr title={actionKey[1]} className="no-underline">
                       {actionKey[0]}
                     </abbr>{' '}
@@ -54,18 +54,18 @@ export const Header = ({ children }: HeaderProps) => {
             </SearchButton>
           </div>
           <div className="flex flex-shrink-0 items-center space-x-6">
-            <ul className="hidden lg:flex items-center space-x-6">
+            <ul className="hidden items-center space-x-6 lg:flex">
               <li>
                 <a
                   href="#"
-                  className="flex items-center space-x-1 font-semibold tracking-tight text-gray-500 dark:text-gray-200 hover:text-gray-600 dark:hover:text-gray-500 transition"
+                  className="flex items-center space-x-1 font-semibold tracking-tight text-gray-500 transition hover:text-gray-600 dark:text-gray-200 dark:hover:text-gray-500"
                 >
                   <span>Help centre</span>
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 20 20"
                     fill="currentColor"
-                    className="w-5 h-5 opacity-50"
+                    className="h-5 w-5 opacity-50"
                   >
                     <path
                       fillRule="evenodd"
@@ -78,14 +78,14 @@ export const Header = ({ children }: HeaderProps) => {
               <li>
                 <a
                   href="#"
-                  className="flex items-center space-x-1 font-semibold tracking-tight text-gray-500 dark:text-gray-200 hover:text-gray-600 dark:hover:text-gray-500 transition"
+                  className="flex items-center space-x-1 font-semibold tracking-tight text-gray-500 transition hover:text-gray-600 dark:text-gray-200 dark:hover:text-gray-500"
                 >
                   <span>Console</span>
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 20 20"
                     fill="currentColor"
-                    className="w-5 h-5 opacity-50"
+                    className="h-5 w-5 opacity-50"
                   >
                     <path
                       fillRule="evenodd"

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -21,10 +21,10 @@ export const TableOfContents = ({ toc }: TableOfContentsProps) => {
 
   return (
     <nav>
-      <h5 className="text-gray-900 dark:text-gray-200 font-semibold text-sm mb-4">
+      <h5 className="mb-4 text-sm font-semibold text-gray-900 dark:text-gray-200">
         On this page
       </h5>
-      <ul className="text-gray-600 text-sm">
+      <ul className="text-sm text-gray-600">
         {items.map((item) => {
           const href = `#${item.id}`
           const active = activeId === item.id

--- a/src/layouts/DocumentationLayout.tsx
+++ b/src/layouts/DocumentationLayout.tsx
@@ -18,11 +18,11 @@ export const DocumentationLayout = ({
 }: DocumentationLayoutProps) => {
   return (
     <>
-      <main className="flex-1 py-10 px-8 mx-auto w-full max-w-8xl flex items-start space-x-8">
-        <div className="flex-shrink-0 sticky top-[6.25rem] border border-black/10 dark:border-white/10 rounded-lg w-72 py-6"></div>
-        <div className="flex-auto flex items-start space-x-8">
+      <main className="mx-auto flex w-full max-w-8xl flex-1 items-start space-x-8 py-10 px-8">
+        <div className="sticky top-[6.25rem] w-72 flex-shrink-0 rounded-lg border border-black/10 py-6 dark:border-white/10"></div>
+        <div className="flex flex-auto items-start space-x-8">
           <div className="flex-auto">{children}</div>
-          <div className="flex-shrink-0 sticky top-[6.25rem] w-64 space-y-6">
+          <div className="sticky top-[6.25rem] w-64 flex-shrink-0 space-y-6">
             <TableOfContents toc={toc} />
             <Contribution />
           </div>

--- a/src/layouts/FullPageLayout.tsx
+++ b/src/layouts/FullPageLayout.tsx
@@ -11,7 +11,7 @@ export const FullPageLayout = ({
 }: FullPageLayoutProps) => {
   return (
     <>
-      <main className="flex-1 py-10 px-8 mx-auto w-full max-w-8xl flex items-start space-x-6">
+      <main className="mx-auto flex w-full max-w-8xl flex-1 items-start space-x-6 py-10 px-8">
         {children}
       </main>
     </>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 const Error = () => {
   return (
-    <div className="flex flex-auto items-center justify-center text-center px-4 py-12 flex-col sm:flex-row">
-      <h1 className="text-2xl sm:text-3xl text-gray-700 dark:text-gray-200 font-bold tracking-tight sm:pr-6 sm:mr-6 sm:border-r dark:border-gray-700">
+    <div className="flex flex-auto flex-col items-center justify-center px-4 py-12 text-center sm:flex-row">
+      <h1 className="text-2xl font-bold tracking-tight text-gray-700 dark:border-gray-700 dark:text-gray-200 sm:mr-6 sm:border-r sm:pr-6 sm:text-3xl">
         404
       </h1>
       <h2 className="text-lg text-gray-500 dark:text-gray-400">

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -10,7 +10,7 @@ export default function Document() {
           rel="stylesheet"
         />
       </Head>
-      <body className="h-full relative bg-gray-50 dark:bg-gray-900">
+      <body className="relative h-full bg-gray-50 dark:bg-gray-900">
         <Main />
         <NextScript />
       </body>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import type { NextPageWithCustomLayout } from '../types'
 
 const Home: NextPageWithCustomLayout = () => {
   return (
-    <div className="py-16 flex flex-1 flex-col justify-center items-center text-center">
+    <div className="flex flex-1 flex-col items-center justify-center py-16 text-center">
       <h1 className="text-6xl font-bold tracking-tight text-gray-900 dark:text-gray-200">
         Welcome to{' '}
         <a
@@ -17,7 +17,7 @@ const Home: NextPageWithCustomLayout = () => {
 
       <p className="my-12 text-2xl text-gray-900 dark:text-gray-400">
         Get started by editing{' '}
-        <code className="bg-gray-100 dark:bg-gray-800 px-3 py-2 text-base font-mono rounded-md">
+        <code className="rounded-md bg-gray-100 px-3 py-2 font-mono text-base dark:bg-gray-800">
           pages/index.tsx
         </code>
       </p>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR adds the [Tailwind CSS Prettier plugin](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) to ensure CSS classes are sorted in a recommend order.