### PR TITLE
Remove .canvas extension

### DIFF
--- a/src/pages/docs/canvas/tags/block.md
+++ b/src/pages/docs/canvas/tags/block.md
@@ -11,7 +11,7 @@ A block provides a way to change how a certain part of a template is rendered bu
 Let’s take the following example to illustrate how a block works and more importantly, how it does not work:
 
 ```canvas {% process=false %}
-{# base.canvas #}
+{# base.html #}
 
 {% for post in posts %}
   {% block post %}
@@ -24,9 +24,9 @@ Let’s take the following example to illustrate how a block works and more impo
 If you render this template, the result would be exactly the same with or without the `block` tag. The `block` inside the `for` loop is just a way to make it overridable by a child template:
 
 ```canvas {% process=false %}
-{# child.canvas #}
+{# child.html #}
 
-{% extends 'base.canvas' %}
+{% extends 'base.html' %}
 
 {% block post %}
   <article>

--- a/src/pages/docs/canvas/tags/deprecated.md
+++ b/src/pages/docs/canvas/tags/deprecated.md
@@ -6,8 +6,8 @@ This page is generally useful to Canvas template developers. Canvas generates a 
 
 ```canvas {% process=false %}
 {# base.html #}
-{% deprecated 'The "base.html" template is deprecated, use "layout.canvas" instead. %}
-{% extends 'layout.canvas' %}
+{% deprecated 'The "base.html" template is deprecated, use "layout.html" instead. %}
+{% extends 'layout.html' %}
 ```
 
 Also you can deprecate a block in the following way:

--- a/src/pages/docs/canvas/tags/embed.md
+++ b/src/pages/docs/canvas/tags/embed.md
@@ -7,8 +7,8 @@ The **embed** tag combines the behaviour of [include](/docs/canvas/tags/include)
 Think of an embedded template as a "micro layout skeleton".
 
 ```canvas {% process=false %}
-{% embed 'teasers_skeleton.canvas' %}
-  {# These blocks are defined in "teasers_skeleton.canvas" and we override them right here: #}
+{% embed 'teasers_skeleton.html' %}
+  {# These blocks are defined in "teasers_skeleton.html" and we override them right here: #}
   {% block left_teaser %}
     Some content for the left teaser box
   {% endblock %}
@@ -35,7 +35,7 @@ Since the use case may not be obvious, let’s look at a simplified example. Ima
 └─────────────────────────────────────┘
 ```
 
-Some pages ("foo.canvas" and "bar.canvas") share the same content structure - two vertically stacked boxes:
+Some pages ("foo.html" and "bar.html") share the same content structure - two vertically stacked boxes:
 
 ```canvas
 ┌─── page layout ─────────────────────┐
@@ -52,7 +52,7 @@ Some pages ("foo.canvas" and "bar.canvas") share the same content structure - tw
 └─────────────────────────────────────┘
 ```
 
-While other pages ("boom.canvas" and "baz.canvas") share a different content structure - two boxes side by side:
+While other pages ("boom.html" and "baz.html") share a different content structure - two boxes side by side:
 
 ```canvas
 ┌─── page layout ─────────────────────┐
@@ -71,7 +71,7 @@ While other pages ("boom.canvas" and "baz.canvas") share a different content str
 
 Without the **embed** tag, you have two ways to design your templates:
 
-- Create two "intermediate" base templates that extend the master layout template: one with vertically stacked boxes to be used by the "foo.canvas" and "bar.canvas" pages and another one with side-by-side boxes for the "boom.canvas" and "baz.canvas" pages.
+- Create two "intermediate" base templates that extend the master layout template: one with vertically stacked boxes to be used by the "foo.html" and "bar.html" pages and another one with side-by-side boxes for the "boom.html" and "baz.html" pages.
 - Embed the markup for the top/bottom and left/right boxes into each page template directly.
 
 These two solutions do not scale well because they each have a major drawback:
@@ -81,13 +81,13 @@ These two solutions do not scale well because they each have a major drawback:
 
 In such a situation, the **embed** tag comes in handy. The common layout code can live in a single base template, and the two different content structures, let’s call them "micro layouts" go into separate templates which are embedded as necessary:
 
-Page template `foo.canvas`:
+Page template `foo.html`:
 
 ```canvas {% process=false %}
-{% extends "layout.canvas" %}
+{% extends "layout.html" %}
 
 {% block content %}
-  {% embed "vertical_boxes_skeleton.canvas" %}
+  {% embed "vertical_boxes_skeleton.html" %}
     {% block top %}
       Some content for the top box
     {% endblock %}
@@ -99,7 +99,7 @@ Page template `foo.canvas`:
 {% endblock %}
 ```
 
-And here is the code for `vertical_boxes_skeleton.canvas`:
+And here is the code for `vertical_boxes_skeleton.html`:
 
 ```canvas {% process=false %}
 <div class="top_box">
@@ -115,7 +115,7 @@ And here is the code for `vertical_boxes_skeleton.canvas`:
 </div>
 ```
 
-The goal of the `vertical_boxes_skeleton.canvas` template being to factor out the HTML markup for the boxes.
+The goal of the `vertical_boxes_skeleton.html` template being to factor out the HTML markup for the boxes.
 
 The **embed** tag takes the exact same arguments as the [include](/docs/canvas/tags/include) tag:
 

--- a/src/pages/docs/canvas/tags/extends.md
+++ b/src/pages/docs/canvas/tags/extends.md
@@ -2,7 +2,7 @@
 title: 'extends'
 ---
 
-The **extends** tag can be used to extend a template from another one. Canvas does not support multiple inheritance. So you can only have one extends tag called per rendering. However, Canvas supports horizontal [reuse](/docs/canvas/tags/use). Let’s define a base template, `base.canvas`, which defines a simple HTML skeleton document:
+The **extends** tag can be used to extend a template from another one. Canvas does not support multiple inheritance. So you can only have one extends tag called per rendering. However, Canvas supports horizontal [reuse](/docs/canvas/tags/use). Let’s define a base template, `base.html`, which defines a simple HTML skeleton document:
 
 ```canvas {% process=false %}
 <!DOCTYPE html>
@@ -31,7 +31,7 @@ In this example, the [block](/docs/canvas/tags/block) tags define four blocks th
 A child template might look like this:
 
 ```canvas {% process=false %}
-{% extends 'base.canvas' %}
+{% extends 'base.html' %}
 
 {% block title %}Home{% endblock %}
 
@@ -123,7 +123,7 @@ Canvas supports dynamic inheritance by using a variable as the base template:
 You can also provide a list of templates that are checked for existence. The first template that exists will be used as a parent:
 
 ```canvas {% process=false %}
-{% extends ['layout.canvas', 'base_layout.canvas'] %}
+{% extends ['layout.html', 'base_layout.html'] %}
 ```
 
 ## Conditional interitance
@@ -131,7 +131,7 @@ You can also provide a list of templates that are checked for existence. The fir
 As the template name for the parent can be any valid Canvas expression, it’s possible to make the inheritance mechanism conditional:
 
 ```canvas {% process=false %}
-{% extends standalone ? 'minimum.canvas' : 'base.canvas' %}
+{% extends standalone ? 'minimum.html' : 'base.html' %}
 ```
 
-In this example, the template will extend the "minimum.canvas" layout template if the `standalone` variable evaluates to `true`, and "base.canvas" otherwise.
+In this example, the template will extend the "minimum.html" layout template if the `standalone` variable evaluates to `true`, and "base.html" otherwise.

--- a/src/pages/docs/canvas/tags/from.md
+++ b/src/pages/docs/canvas/tags/from.md
@@ -5,7 +5,7 @@ title: 'from'
 The `from` tag imports [macro](/docs/canvas/tags/macro) names into the current namespace. The tag is documented in detail in the documentation for the [macro](/docs/canvas/tags/macro) tag.
 
 ```canvas {% process=false %}
-{% from 'forms.canvas' import input as input, textarea %}
+{% from 'forms.html' import input as input, textarea %}
 
 <p>{{ input('password', '', 'password') }}</p>
 <p>{{ textarea('comment') }}</p>

--- a/src/pages/docs/canvas/tags/include.md
+++ b/src/pages/docs/canvas/tags/include.md
@@ -5,9 +5,9 @@ title: 'include'
 The **include** statement includes a template and returns the rendered content of that file:
 
 ```canvas {% process=false %}
-{% include 'header.canvas' %}
+{% include 'header.html' %}
   Body
-{% include 'footer.canvas' %}
+{% include 'footer.html' %}
 ```
 
 It is recommended to use the [include](/docs/canvas/functions/include) function instead as it provides the same features with a bit more flexibility:
@@ -18,17 +18,17 @@ It is recommended to use the [include](/docs/canvas/functions/include) function 
 ```canvas {% process=false %}
 {# Store a rendered template in a variable #}
 {% set content %}
-  {% include 'template.canvas' %}
+  {% include 'template.html' %}
 {% endset %}
 {# vs #}
-{% set content = include('template.canvas') %}
+{% set content = include('template.html') %}
 
 {# Filter a rendered template #}
 {% filter upper %}
-  {% include 'template.canvas' %}
+  {% include 'template.html' %}
 {% endfilter %}
 {# vs #}
-{{ include('template.canvas') | upper }}
+{{ include('template.html') | upper }}
 ```
 
 - The [include](/docs/canvas/functions/include) function does not impose any specific order for arguments thanks to named arguments.
@@ -36,44 +36,44 @@ It is recommended to use the [include](/docs/canvas/functions/include) function 
 Included templates have access to the variables of the active context. You can add additional variables by passing them after the `with` keyword:
 
 ```canvas {% process=false %}
-{# template.canvas will have access to the variables from the current context and the additional ones provided #}
-{% include 'template.canvas' with { 'foo': 'bar' } %}
+{# template.html will have access to the variables from the current context and the additional ones provided #}
+{% include 'template.html' with { 'foo': 'bar' } %}
 
 {% set vars = { 'foo': 'bar' } %}
-{% include 'template.canvas' with vars %}
+{% include 'template.html' with vars %}
 ```
 
 You can disable access to the context by appending the `only` keyword:
 
 ```canvas {% process=false %}
 {# only the foo variable will be accessible #}
-{% include 'template.canvas' with { 'foo': 'bar' } only %}
+{% include 'template.html' with { 'foo': 'bar' } only %}
 ```
 
 ```canvas {% process=false %}
 {# no variables will be accessible #}
-{% include 'template.canvas' only %}
+{% include 'template.html' only %}
 ```
 
 The template name can be any valid Canvas expression:
 
 ```canvas {% process=false %}
 {% include some_var %}
-{% include ajax ? 'ajax.canvas' : 'not_ajax.canvas' %}
+{% include ajax ? 'ajax.html' : 'not_ajax.html' %}
 ```
 
 You can mark an include with `ignore missing` in which case Canvas will ignore the statement if the template to be included does not exist. It has to be placed just after the template name. Here are some valid examples:
 
 ```canvas {% process=false %}
-{% include 'sidebar.canvas' ignore missing %}
-{% include 'sidebar.canvas' ignore missing with { 'foo': 'bar' } %}
-{% include 'sidebar.canvas' ignore missing only %}
+{% include 'sidebar.html' ignore missing %}
+{% include 'sidebar.html' ignore missing with { 'foo': 'bar' } %}
+{% include 'sidebar.html' ignore missing only %}
 ```
 
 You can also provide a list of templates that are checked for existence before inclusion. The first template that exists will be included:
 
 ```canvas {% process=false %}
-{% include ['page_detailed.canvas', 'page.canvas'] %}
+{% include ['page_detailed.html', 'page.html'] %}
 ```
 
 If `ignore missing` is given, it will fall back to rendering nothing if none of the templates exist, otherwise it will throw an exception.

--- a/src/pages/docs/canvas/tags/macro.md
+++ b/src/pages/docs/canvas/tags/macro.md
@@ -6,7 +6,7 @@ Macros are comparable with functions in regular programming languages. They are 
 
 Macros are defined in regular templates.
 
-Imagine having a generic helper template that define how to render HTML forms via macros (called `forms.canvas`):
+Imagine having a generic helper template that define how to render HTML forms via macros (called `forms.html`):
 
 ```canvas {% process=false %}
 {% macro input(name, value, type = 'text', size = 20) %}
@@ -34,10 +34,10 @@ There are two ways to import macros. You can import the complete template contai
 To import all macros from a template into a local variable, use the [import](/docs/canvas/tags/import) tag:
 
 ```canvas {% process=false %}
-{% import 'forms.canvas' as forms %}
+{% import 'forms.html' as forms %}
 ```
 
-The above **import** call imports the `forms.canvas` file (which can contain only macros, or a template and some macros), and import the macros as items of the `forms` local variable.
+The above **import** call imports the `forms.html` file (which can contain only macros, or a template and some macros), and import the macros as items of the `forms` local variable.
 
 The macros can then be called at will in the *current* template:
 
@@ -49,7 +49,7 @@ The macros can then be called at will in the *current* template:
 Alternatively you can import names from the template into the current namespace via the [from](/docs/canvas/tags/from) tag:
 
 ```canvas {% process=false %}
-{% from 'forms.canvas' import input as input, textarea %}
+{% from 'forms.html' import input as input, textarea %}
 
 <p>{{ input('password', '', 'password') }}</p>
 <p>{{ textarea('comment') }}</p>
@@ -80,9 +80,9 @@ When calling **import** or **from** from a **macro** tag, the imported macros ar
 You can check if a macro is defined via the `defined` test:
 
 ```canvas {% process=false %}
-{% import 'macros.canvas' as macros %}
+{% import 'macros.html' as macros %}
 
-{% from 'macros.canvas' import hello %}
+{% from 'macros.html' import hello %}
 
 {% if macros.hello is defined -%}
   OK

--- a/src/pages/docs/canvas/tags/use.md
+++ b/src/pages/docs/canvas/tags/use.md
@@ -7,7 +7,7 @@ Horizontal reuse is an advanced Canvas feature that is hardly ever used in regul
 Template inheritance is one of the most powerful features of Canvas but it is limited to single inheritance; a template can only extend one other template. This limitation makes template inheritance simple to understand and easy to debug.
 
 ```canvas {% process=false %}
-{% extends 'base.canvas' %}
+{% extends 'base.html' %}
 
 {% block title %}{% endblock %}
 {% block content %}{% endblock %}
@@ -16,18 +16,18 @@ Template inheritance is one of the most powerful features of Canvas but it is li
 Horizontal reuse is a way to achieve the same goal as multiple inheritance, but without the associated complexity:
 
 ```canvas {% process=false %}
-{% extends 'base.canvas' %}
+{% extends 'base.html' %}
 
-{% use 'blocks.canvas' %}
+{% use 'blocks.html' %}
 
 {% block title %}{% endblock %}
 {% block content %}{% endblock %}
 ```
 
-The **use** statement tells Canvas to import the blocks defined in `blocks.canvas` into the current template (it's like macros, but for blocks):
+The **use** statement tells Canvas to import the blocks defined in `blocks.html` into the current template (it's like macros, but for blocks):
 
 ```canvas {% process=false %}
-{# blocks.canvas #}
+{# blocks.html #}
 
 {% block sidebar %}{% endblock %}
 ```
@@ -35,7 +35,7 @@ The **use** statement tells Canvas to import the blocks defined in `blocks.canva
 In this example, the **use** statement imports the `sidebar` block into the main template. The code is mostly equivalent to the following one (the imported blocks are not outputted automatically):
 
 ```canvas {% process=false %}
-{% extends 'base.canvas' %}
+{% extends 'base.html' %}
 
 {% block sidebar %}{% endblock %}
 {% block title %}{% endblock %}
@@ -44,12 +44,12 @@ In this example, the **use** statement imports the `sidebar` block into the main
 
 The **use** tag only imports a template if it does not extend another template, if it does not define macros, and if the body is empty. But it can *use* other templates. Because **use** statements are resolved independtly of the context passed to the template, the template reference cannot be an expression.
 
-The main template can also override any imported block. If the template already defines the `sidebar` block, then the one defined in `blocks.canvas` is ignored. To avoid name conflicts, you can rename imported blocks:
+The main template can also override any imported block. If the template already defines the `sidebar` block, then the one defined in `blocks.html` is ignored. To avoid name conflicts, you can rename imported blocks:
 
 ```canvas {% process=false %}
-{% extends 'base.canvas' %}
+{% extends 'base.html' %}
 
-{% use 'blocks.canvas' with sidebar as base_sidebar, title as base_title %}
+{% use 'blocks.html' with sidebar as base_sidebar, title as base_title %}
 
 {% block sidebar %}{% endblock %}
 {% block title %}{% endblock %}
@@ -59,9 +59,9 @@ The main template can also override any imported block. If the template already 
 The [parent()](/docs/canvas/functions/parent) function automatically determines the correct inheritance tree, so it can be used when overriding a block defined in an imported template:
 
 ```canvas {% process=false %}
-{% extends 'base.canvas' %}
+{% extends 'base.html' %}
 
-{% use 'blocks.canvas' %}
+{% use 'blocks.html' %}
 
 {% block sidebar %}
   {{ parent() }}
@@ -71,14 +71,14 @@ The [parent()](/docs/canvas/functions/parent) function automatically determines 
 {% block content %}{% endblock %}
 ```
 
-In this example, the **parent()** function will correctly call the `sidebar` block from the `blocks.canvas` template.
+In this example, the **parent()** function will correctly call the `sidebar` block from the `blocks.html` template.
 
 Renaming allows you to simulate inheritance by calling the "parent" block:
 
 ```canvas {% process=false %}
-{% extends 'base.canvas' %}
+{% extends 'base.html' %}
 
-{% use 'blocks.canvas' with sidebar as parent_sidebar %}
+{% use 'blocks.html' with sidebar as parent_sidebar %}
 
 {% block sidebar %}
   {{ block('parent_sidebar') }}

--- a/src/pages/docs/getting-started/create.md
+++ b/src/pages/docs/getting-started/create.md
@@ -34,7 +34,7 @@ First lets create a new page on your newly created project.
 1. Login to your newly created project. You can quickly log into your project through the **Projects** page on your [Agency Console](https://blutui.com/app).
 2. Once logged in, from the **Site Dashboard**, navigate to **Pages** using the navigation sidebar and click the **Add page** button at the top right side of the page.
 3. Enter the required information for your page. The **Layout** is the file path to the page template. For best practice it is recommended that you create your page templates in the `pages` directory of your Canvas.
-4. If you have not created the page template, go to the `pages` directory in your Canvas template files and add create your  new page layout. For example if you set the `Layout` to `pages/about.canvas`, add `about.canvas` to your `pages` directory.
+4. If you have not created the page template, go to the `pages` directory in your Canvas template files and add create your  new page layout. For example if you set the `Layout` to `pages/about.html`, add `about.html` to your `pages` directory.
 
 In your newly created Canvas template add the following code:
 
@@ -98,7 +98,7 @@ Like most content types in Blutui, it all starts in the site dashboard. Visit th
 
 You will notice that all data types require a value for the `Name` field, this is used to identify the data type in your code.
 
-Let's create a template that will render this collection, to do this you need the collection handle. In this example the handle is `staff`. First create a `collections` folder in our Canvas `views` directory, and add a file called `staff.canvas`, with:
+Let's create a template that will render this collection, to do this you need the collection handle. In this example the handle is `staff`. First create a `collections` folder in our Canvas `views` directory, and add a file called `staff.html`, with:
 
 ```canvas {% process=false %}
 {% set collection = cms.collection('staff') %}
@@ -120,7 +120,7 @@ In this code example you are calling the collection, setting it to a `collection
 {% extends 'templates/default' %}
 
 {% block body %}
-  {% include 'collections/staff.canvas' %}
+  {% include 'collections/staff.html' %}
 {% endblock %}
 ```
 
@@ -173,7 +173,7 @@ Now lets add a contact form on your site. The process of making a form is simila
 
 {% image src="https://cdn.blutui.com/uploads/assets/Dev/getting-started/form.gif" alt="Adding a form" /%}
 
-Now that your new form is created, lets add this form to your Canvas. At the top of the form template we want to [import](/docs/canvas/tags/import) `macros/form.canvas` into the `ui` variable, the file responsible for the markup and styling of your form inputs. We've created a form macro template to help you get started. You can find the code for the `macros/form.canvas` macro on [Gist](https://gist.github.com/jayan-blutui/228a410ebc3d0779011f019d0620ef1e). You can use the form macro like:
+Now that your new form is created, lets add this form to your Canvas. At the top of the form template we want to [import](/docs/canvas/tags/import) `macros/form.html` into the `ui` variable, the file responsible for the markup and styling of your form inputs. We've created a form macro template to help you get started. You can find the code for the `macros/form.html` macro on [Gist](https://gist.github.com/jayan-blutui/228a410ebc3d0779011f019d0620ef1e). You can use the form macro like:
 
 ```canvas {% process=false %}
 {% import 'macros/form' as ui %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR removes the `.canvas` file extension in favour of `.html` while we work on the `.canvas` syntax highlighting and language server.