### PR TITLE
Enable sidebar scroll and add code fence filenames

### DIFF
--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -3,8 +3,9 @@ import Prism from 'prismjs'
 import cn from 'clsx'
 
 export interface CodeProps {
+  'data-language': string
   children?: React.ReactNode
-  'data-language': any
+  filename?: string
 }
 
 Prism.languages.canvas = {
@@ -68,7 +69,11 @@ Prism.hooks.add('after-tokenize', (env) => {
   markupTemplating.tokenizePlaceholders(env, 'canvas')
 })
 
-export const Code = ({ children, 'data-language': language }: CodeProps) => {
+export const Code = ({
+  children,
+  'data-language': language,
+  filename,
+}: CodeProps) => {
   const [copied, setCopied] = useState(false)
   const ref = useRef(null)
 
@@ -79,8 +84,17 @@ export const Code = ({ children, 'data-language': language }: CodeProps) => {
   const lang = language === 'md' ? 'markdoc' : language || 'markdoc'
 
   return (
-    <div className="code not-prose" aria-live="polite">
-      <pre key={children as any} ref={ref} className={cn(`language-${lang}`)}>
+    <div className="code not-prose relative" aria-live="polite">
+      {filename && (
+        <div className="absolute top-0 z-10 w-full truncate rounded-t-xl bg-zinc-500/30 py-2 px-4 text-sm font-medium text-zinc-300">
+          {filename}
+        </div>
+      )}
+      <pre
+        key={children as any}
+        ref={ref}
+        className={cn(`language-${lang}`, filename ? 'px-4 pt-12 pb-4' : 'p-4')}
+      >
         <code>{children}</code>
       </pre>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import cn from 'clsx'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-// import scrollIntoView from 'scroll-into-view-if-needed'
+import scrollIntoView from 'scroll-into-view-if-needed'
 
 export interface Item {
   title?: string
@@ -86,22 +86,22 @@ export const Sidebar = ({ items, className }: SidebarProps) => {
   const sidebarRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // useEffect(() => {
-  //   const activeElement = sidebarRef.current?.querySelector('li.active')
+  useEffect(() => {
+    const activeElement = sidebarRef.current?.querySelector('li.active')
 
-  //   if (activeElement && window.innerWidth > 767) {
-  //     // const scroll = () => {
-  //     //   scrollIntoView(activeElement, {
-  //     //     block: 'center',
-  //     //     inline: 'center',
-  //     //     scrollMode: 'always',
-  //     //     boundary: containerRef.current,
-  //     //     behavior: 'smooth',
-  //     //   })
-  //     // }
-  //     // scroll()
-  //   }
-  // })
+    if (activeElement && window.innerWidth > 767) {
+      const scroll = () => {
+        scrollIntoView(activeElement, {
+          block: 'center',
+          inline: 'center',
+          scrollMode: 'always',
+          boundary: containerRef.current,
+          behavior: 'smooth',
+        })
+      }
+      scroll()
+    }
+  })
 
   return (
     <>

--- a/src/markdoc/nodes/fence.markdoc.ts
+++ b/src/markdoc/nodes/fence.markdoc.ts
@@ -4,7 +4,12 @@ import { Code } from '@/components/Code'
 
 export const fence: Schema<Config, typeof Code> = {
   render: Code,
-  attributes: nodes.fence.attributes,
+  attributes: {
+    content: { type: String, render: false, required: true },
+    language: { type: String, render: 'data-language' },
+    process: { type: Boolean, render: false, default: true },
+    filename: { type: String, render: 'filename' },
+  },
   transform(node, config) {
     const attributes = node.transformAttributes(config)
     const children = node.children.length

--- a/src/markdoc/nodes/fence.markdoc.ts
+++ b/src/markdoc/nodes/fence.markdoc.ts
@@ -5,9 +5,7 @@ import { Code } from '@/components/Code'
 export const fence: Schema<Config, typeof Code> = {
   render: Code,
   attributes: {
-    content: { type: String, render: false, required: true },
-    language: { type: String, render: 'data-language' },
-    process: { type: Boolean, render: false, default: true },
+    ...nodes.fence.attributes,
     filename: { type: String, render: 'filename' },
   },
   transform(node, config) {

--- a/src/pages/docs/canvas/getting-started/templating.md
+++ b/src/pages/docs/canvas/getting-started/templating.md
@@ -77,7 +77,7 @@ It’s easier to understand the concept by starting with an example.
 
 Let’s define a base template, **base.html**, which defines an HTML skeleton document that might be used for a two-column page:
 
-```canvas {% process=false %}
+```canvas {% process=false filename="base.html" %}
 <!DOCTYPE html>
 <html>
   <head>
@@ -102,7 +102,7 @@ In this example, the [block](/docs/canvas/tags/block) tags define four blocks th
 
 A child template might look like this:
 
-```canvas {% process=false %}
+```canvas {% process=false filename="index.html" %}
 {% extends 'base.html' %}
 
 {% block title %}Index{% endblock %}

--- a/src/pages/docs/courier/configuration.md
+++ b/src/pages/docs/courier/configuration.md
@@ -12,7 +12,7 @@ courier init
 
 This command will generate:
 
-```json {% process=false %}
+```json {% process=false filename="courier.json" %}
 {
   "handle": "",
   "site": "",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,13 +14,6 @@ const Home: NextPageWithCustomLayout = () => {
           blutui.com
         </a>
       </h1>
-
-      <p className="my-12 text-2xl text-gray-900 dark:text-gray-400">
-        Get started by editing{' '}
-        <code className="rounded-md bg-gray-100 px-3 py-2 font-mono text-base dark:bg-gray-800">
-          pages/index.tsx
-        </code>
-      </p>
     </div>
   )
 }

--- a/src/styles/prism.css
+++ b/src/styles/prism.css
@@ -10,7 +10,7 @@ pre[class*="language-"] {
 
 /* Code blocks */
 pre[class*="language-"] {
-  @apply p-4 my-2 overflow-auto rounded-xl;
+  @apply my-2 overflow-auto rounded-xl;
 }
 
 :not(pre) > code[class*="language-"],


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR enables scroll into view for the `Sidebar` component and add the ability to add filenames to the `fence` node.