### PR TITLE
fix: sidebar item sometimes inactive when using anchor link

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ export interface Item {
 }
 
 const Folder = ({ item }: { item: Item }) => {
-  const { asPath: route } = useRouter()
+  const { pathname: route } = useRouter()
 
   const active = item.url && [route, route + '/'].includes(item.url + '/')
 
@@ -35,7 +35,7 @@ const Folder = ({ item }: { item: Item }) => {
 }
 
 const File = ({ item }: { item: Item }) => {
-  const { asPath: route } = useRouter()
+  const { pathname: route } = useRouter()
 
   const active = item.url && [route, route + '/'].includes(item.url + '/')
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR fixes an issue that occurs with the active state of a sidebar item where, if a anchor link is clicked then the active state becomes inactive even if you're on the same page.

This issue is fixed by using the `pathname` instead of `asPath` from the router hook.