### PR TITLE
feat: add TOC to guides single page

### DIFF
--- a/src/components/table-of-contents.tsx
+++ b/src/components/table-of-contents.tsx
@@ -6,10 +6,14 @@ import { useActiveId } from '@/utils/use-active-id'
 import type { Section } from '@/utils/collect-headings'
 
 export interface TableOfContentsProps {
+  title?: string
   toc: Section[]
 }
 
-export const TableOfContents = ({ toc }: TableOfContentsProps) => {
+export const TableOfContents = ({
+  title = 'On this page',
+  toc,
+}: TableOfContentsProps) => {
   const items = toc.filter(
     (item) => item.id && (item.level === 2 || item.level === 3)
   )
@@ -22,7 +26,7 @@ export const TableOfContents = ({ toc }: TableOfContentsProps) => {
         {items.length >= 1 && (
           <>
             <h5 className="mb-4 text-sm font-semibold text-zinc-900 dark:text-zinc-200">
-              On this page
+              {title}
             </h5>
             <ul className="text-sm text-zinc-600">
               {items.map((item) => {

--- a/src/layouts/guides.tsx
+++ b/src/layouts/guides.tsx
@@ -3,16 +3,23 @@ import Link from 'next/link'
 
 import { useArticleContext } from '@/context/article-context'
 import { getGuideBySlug } from '@/navigation/guides'
+import { Section } from '@/utils/collect-headings'
 
 import { ArrowLongLeft } from '@/components/icons/arrow-long-left'
 import { Footer } from '@/components/footer'
+import { TableOfContents } from '@/components/table-of-contents'
 
 export interface GuidesLayoutProps {
   layoutProps: any
+  toc: Section[]
   children: React.ReactNode
 }
 
-export const GuidesLayout = ({ layoutProps, children }: GuidesLayoutProps) => {
+export const GuidesLayout = ({
+  layoutProps,
+  toc,
+  children,
+}: GuidesLayoutProps) => {
   const { pathname } = useRouter()
   const articleContext = useArticleContext()
 
@@ -25,8 +32,8 @@ export const GuidesLayout = ({ layoutProps, children }: GuidesLayoutProps) => {
 
   return (
     <main>
-      <header className="border-b px-8 py-8 dark:border-zinc-800">
-        <div className="mx-auto max-w-screen-md">
+      <header className="border-b py-8 dark:border-zinc-800">
+        <div className="max-w-8xl mx-auto px-8">
           <div className="mb-4">
             <Link
               href="/guides"
@@ -56,10 +63,13 @@ export const GuidesLayout = ({ layoutProps, children }: GuidesLayoutProps) => {
           )}
         </div>
       </header>
-      <div className="px-8">
-        <div className="max-w-8xl mx-auto w-full py-8">{children}</div>
-        <Footer />
+      <div className="max-w-8xl mx-auto w-full px-8 py-8">
+        <div className="flex gap-8">
+          <TableOfContents title="In this guide" toc={toc} />
+          <div>{children}</div>
+        </div>
       </div>
+      <Footer />
     </main>
   )
 }

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -35,7 +35,7 @@ const GuideItem = ({ item }: { item: GuidesNavigationItem }) => {
           {item.tags.map((tag, i) => (
             <span
               key={i}
-              className="rounded-md px-2 py-1 text-xs font-medium uppercase text-zinc-500 ring-1 ring-zinc-200 dark:text-zinc-500 dark:ring-zinc-600"
+              className="rounded-md px-2 py-1 font-mono text-xs font-medium uppercase text-zinc-500 ring-1 ring-zinc-200 dark:text-zinc-500 dark:ring-zinc-600"
             >
               {tag}
             </span>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,7 +55,7 @@ export default {
               letterSpacing: '-0.025em',
             },
             'h2, h3, h4': {
-              'scroll-margin-top': '6.25rem',
+              'scroll-margin-top': '8.5rem',
             },
             a: {
               fontWeight: theme('fontWeight.semibold'),


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR adds a TOC to each guide page. Allowing for better navigation. This PR also fixes the `scroll-margin-top` value to ensure headings aren't under the header.