### PR TITLE
fix: featured items not at the top

### DIFF
--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -47,9 +47,17 @@ const GuideItem = ({ item }: { item: GuidesNavigationItem }) => {
 }
 
 export default function Guides() {
-  const sortedGuides = guidesNavigation.sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  )
+  const sortedGuides = guidesNavigation.sort((a, b) => {
+    // Compare the featured property first
+    if (a.featured && !b.featured) {
+      return -1 // A comes first
+    } else if (!a.featured && b.featured) {
+      return 1 // B comes first
+    }
+
+    // If A & B both have featured set to false, compare by date.
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  })
 
   const { items: guides, hasMorePages, loadMore } = usePagination(sortedGuides)
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR ensures that featured items are always shown at the top of the list of guides, previously they were ordered by date regardless of whether they are featured or not.