### PR TITLE
change: Update Next.js to 14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@markdoc/next.js": "^0.3.7",
         "@vercel/analytics": "^1.1.1",
         "clsx": "^2.1.0",
-        "next": "^14.0.4",
+        "next": "^14.1.1-canary.20",
         "prismjs": "^1.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -477,9 +477,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.4.tgz",
-      "integrity": "sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ=="
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.1-canary.20.tgz",
+      "integrity": "sha512-fN22v9q3d9rJMsNGah5LLTd5RfqX7BAMyFbVeuC3r/qgChMWvhGc5rX8n3hS7o3D24BOlklLx0eDgnrrGjs68Q=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.1.0",
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.4.tgz",
-      "integrity": "sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.1-canary.20.tgz",
+      "integrity": "sha512-SKoiTxAiXi3zY78Us1GYf8WNFXkTSjoMf74A06irxMRf2X935JuoAZMo/7lUzgLG/LE6wPLwf+vwICd/Oe+C1w==",
       "cpu": [
         "arm64"
       ],
@@ -552,9 +552,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz",
-      "integrity": "sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.1-canary.20.tgz",
+      "integrity": "sha512-fOetQxD6OENSRJyv6xOpYZjB5QCBAtyJFhM/xxdRcy/v3ac9Tr3x0xaPSR/G0LeiJmHQD0tISRCbJrhZG+1kwg==",
       "cpu": [
         "x64"
       ],
@@ -567,9 +567,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz",
-      "integrity": "sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.1-canary.20.tgz",
+      "integrity": "sha512-JFHWPpBY9oOY1tF8SGvyBkyBLjaHHZ5jashO4Xc9ULPehdzcdVmXrmTzg91WYJSwInfoLHGsXNPH5EdIObEjKA==",
       "cpu": [
         "arm64"
       ],
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz",
-      "integrity": "sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.1-canary.20.tgz",
+      "integrity": "sha512-2cDbg7ucNqghMnhMhEWI2AM+EHKGJtzdzMMbUyJ3VWKKkU3zVVIaXWtvQBQpNYVHVSQOyRIQM8XlqGiE8/eypw==",
       "cpu": [
         "arm64"
       ],
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.4.tgz",
-      "integrity": "sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.1-canary.20.tgz",
+      "integrity": "sha512-Z6XquDj3HoMmA09LvL3aSK/S/JqWNQUBGj3tQUMhFqgFsaWWxU1xj7oTI6WumQdCCC4GrVEbDmeD0Oe9/Dt3wQ==",
       "cpu": [
         "x64"
       ],
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.4.tgz",
-      "integrity": "sha512-m8z/6Fyal4L9Bnlxde5g2Mfa1Z7dasMQyhEhskDATpqr+Y0mjOBZcXQ7G5U+vgL22cI4T7MfvgtrM2jdopqWaw==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.1-canary.20.tgz",
+      "integrity": "sha512-8zixka/J45Mrr09D4LMUjb5zsGhD1vWxzLuQciNSdVHtO7DOHyYaC/r4zmgY/Joc4LG4f8JgAQWhnlE1m0fXyQ==",
       "cpu": [
         "x64"
       ],
@@ -627,9 +627,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz",
-      "integrity": "sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.1-canary.20.tgz",
+      "integrity": "sha512-wrGCWPaUu+ZHbTBQWl/LiDAEjmZ55VxnWn4gZBzxBi0MBW/vRg12TqVc1k7Ha/Nr7VSQOWhtZyhrPX9v9Wjfyg==",
       "cpu": [
         "arm64"
       ],
@@ -642,9 +642,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz",
-      "integrity": "sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.1-canary.20.tgz",
+      "integrity": "sha512-Mf39LlWgWNPfNRRJqADu+ajKdxWAZoITfbsRKxY85EVrGCZhcFR1FOcVRIjcAKKDGaggmSrmnAcK87DM4lhSuA==",
       "cpu": [
         "ia32"
       ],
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz",
-      "integrity": "sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.1-canary.20.tgz",
+      "integrity": "sha512-CpRmtrfCuTxii84Fivox7En3D690KqK4Kd1Kwj0GiB0EJhrQ1+Emximsrl6srxDoAWAceDcKuTXP9NVXkcojqw==",
       "cpu": [
         "x64"
       ],
@@ -2521,11 +2521,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
-    },
     "node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -3402,18 +3397,17 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.0.4.tgz",
-      "integrity": "sha512-qbwypnM7327SadwFtxXnQdGiKpkuhaRLE2uq62/nRul9cj9KhQ5LhHmlziTNqUidZotw/Q1I9OjirBROdUJNgA==",
+      "version": "14.1.1-canary.20",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.1.1-canary.20.tgz",
+      "integrity": "sha512-MTH5ScZMryZ2pmL5yN6Utd/qbJNIvxPS+R5aBCDjuSz8twyVlY0V7FgnpsbCwPnF/iq2pgoytAL1aTErnK1Z4w==",
       "dependencies": {
-        "@next/env": "14.0.4",
+        "@next/env": "14.1.1-canary.20",
         "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
-        "caniuse-lite": "^1.0.30001406",
+        "caniuse-lite": "^1.0.30001579",
         "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1",
-        "watchpack": "2.4.0"
+        "styled-jsx": "5.1.1"
       },
       "bin": {
         "next": "dist/bin/next"
@@ -3422,15 +3416,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.0.4",
-        "@next/swc-darwin-x64": "14.0.4",
-        "@next/swc-linux-arm64-gnu": "14.0.4",
-        "@next/swc-linux-arm64-musl": "14.0.4",
-        "@next/swc-linux-x64-gnu": "14.0.4",
-        "@next/swc-linux-x64-musl": "14.0.4",
-        "@next/swc-win32-arm64-msvc": "14.0.4",
-        "@next/swc-win32-ia32-msvc": "14.0.4",
-        "@next/swc-win32-x64-msvc": "14.0.4"
+        "@next/swc-darwin-arm64": "14.1.1-canary.20",
+        "@next/swc-darwin-x64": "14.1.1-canary.20",
+        "@next/swc-linux-arm64-gnu": "14.1.1-canary.20",
+        "@next/swc-linux-arm64-musl": "14.1.1-canary.20",
+        "@next/swc-linux-x64-gnu": "14.1.1-canary.20",
+        "@next/swc-linux-x64-musl": "14.1.1-canary.20",
+        "@next/swc-win32-arm64-msvc": "14.1.1-canary.20",
+        "@next/swc-win32-ia32-msvc": "14.1.1-canary.20",
+        "@next/swc-win32-x64-msvc": "14.1.1-canary.20"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -4980,18 +4974,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@markdoc/next.js": "^0.3.7",
     "@vercel/analytics": "^1.1.1",
     "clsx": "^2.1.0",
-    "next": "^14.0.4",
+    "next": "^14.1.1-canary.20",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/pages/changelog/index.md
+++ b/src/pages/changelog/index.md
@@ -7,6 +7,24 @@ description: 'A continuous stream of changes made to the Blutui platform.'
 Please use the ISO standard date and time format.
 {% /comment %}
 
+{% changelog date="2024-01-22" %}
+{% badge status="success" %}Added{% /badge %}
+
+- Added favicons for project images in the **Agency Console**.
+- Added [`image_url`](/docs/canvas/filters/image_url) filter to the **Canvas** templating language, to allow you to retrieve an optimised image.
+
+{% badge status="warning" %}Removed{% /badge %}
+
+- Removed the refresh domain button on the domain list view in the **Agency Console**.
+{% /changelog %}
+
+{% changelog date="2024-01-15" %}
+{% badge status="success" %}Added{% /badge %}
+
+- Added the ability to add a SEO title and SEO description to blog posts in the **Project Dashboard**.
+- Added the ability to view `webp` image thumbnails in the **Project Dashboard**.
+{% /changelog %}
+
 {% changelog date="2023-12-21" %}
 {% badge status="success" %}Added{% /badge %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR updates the project to `next` 14.1.1 (canary) as version `14.1.0` does not work.