### PR TITLE
change: Add chore prefix for all dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,15 @@ updates:
     # Check for updates daily
     schedule:
       interval: 'daily'
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   # Enable version updates for Github Actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR adds a `chore` prefix to all Dependabot PR's