### PR TITLE
change: Use Cassette instead of Template

### DIFF
--- a/src/pages/schemas/v1/schema.json.tsx
+++ b/src/pages/schemas/v1/schema.json.tsx
@@ -25,8 +25,8 @@ const schema = {
       type: ['string', 'null'],
       deprecated: true,
     },
-    template: {
-      description: 'The template handle for this template',
+    cassette: {
+      description: 'The handle for this Cassette',
       type: ['string', 'null'],
     },
   },


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR updates the Courier config schema to use `cassette` instead of `template`.