### PR TITLE
Upload markdown content files to Cloudflare R2 git action

### DIFF
--- a/.github/workflows/upload-to-r2.yml
+++ b/.github/workflows/upload-to-r2.yml
@@ -7,8 +7,6 @@ on:
     paths:
       - 'content/**/*.md'   
       - 'content/**/*.mdx'  
-  schedule:
-    - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
 
 jobs:
   upload-to-r2:
@@ -33,8 +31,6 @@ jobs:
             --include "*.md" \
             --include "*.mdx" \
             --delete
-          
-          echo "Sync complete"
       
       - name: Upload summary
         run: |


### PR DESCRIPTION
Upload markdown content files to Cloudflare R2 git action from the main branch - on push or a weekly basis 