### PR TITLE
fix: Canvas syntax errors

### DIFF
--- a/content/docs/canvas/tags/apply.md
+++ b/content/docs/canvas/tags/apply.md
@@ -7,7 +7,7 @@ The **apply** tag allows you to apply Canvas filters on a block of template data
 ```canvas
 {% apply upper %}
   This text becomes uppercase
-{% endapply>
+{% endapply %}
 ```
 
 You can also chain filters and pass arguments to them:
@@ -15,7 +15,7 @@ You can also chain filters and pass arguments to them:
 ```canvas
 {% apply lower | escape('html') %}
   <strong>SOME TEXT</strong>
-{% endapply>
+{% endapply %}
 
 {# outputs "&lt;strong&gt;some text&lt;/strong&gt;" #}
 ```

--- a/content/docs/canvas/tags/autoescape.md
+++ b/content/docs/canvas/tags/autoescape.md
@@ -5,32 +5,32 @@ title: 'autoescape'
 Autoescaping is turned on by default. You can mark a section of a template to be escaped or not by using the `autoescape` tag:
 
 ```canvas
-{% autoescape>
+{% autoescape %}
   Everything will be automatically escaped in this block
   using the HTML strategy
-{% endautoescape>
+{% endautoescape %}
 
 {% autoescape 'html' %}
   Everything will be automatically escaped in this block
   using the HTML strategy
-{% endautoescape>
+{% endautoescape %}
 
 {% autoescape 'js' %}
   Everything will be automatically escaped in this block
   using the js escaping strategy
-{% endautoescape>
+{% endautoescape %}
 
 {% autoescape false %}
   Everything will be outputted as is in this block
-{% endautoescape>
+{% endautoescape %}
 ```
 
 When automatic escaping is enabled everything is escaped by default except for values explicitly marked as safe. Those can be marked in the template by using the [raw](/docs/canvas/filters/raw) filter:
 
 ```canvas
-{% autoescape>
+{% autoescape %}
   {{ safe_value | raw }}
-{% endautoescape>
+{% endautoescape %}
 ```
 
 Functions and tags returning template data (like [macro](/docs/canvas/tags/macro) and [parent](/docs/canvas/functions/parent)) always return safe markup. Canvas is smart enough to not escape an already escaped value by the [escape](/docs/canvas/filters/escape) filter.

--- a/content/docs/canvas/tags/block.md
+++ b/content/docs/canvas/tags/block.md
@@ -13,8 +13,8 @@ Let's take the following example to illustrate how a block works and more import
 ```canvas
 {# base.html #}
 
-{% for post in posts>
-  {% block post>
+{% for post in posts %}
+  {% block post %}
     <h1>{{ post.title }}</h1>
     <p>{{ post.body }}</p>
   {% endblock %}
@@ -28,7 +28,7 @@ If you render this template, the result would be exactly the same with or withou
 
 {% extends 'base.html' %}
 
-{% block post>
+{% block post %}
   <article>
     <header>{{ post.title }}</header>
     <section>{{ post.text }}</section>
@@ -39,7 +39,7 @@ If you render this template, the result would be exactly the same with or withou
 Now, when rendering the child template, the loop is going to use the block defined in the child template instead of the one defined in the base one; the executed template is then equivalent to the following one:
 
 ```canvas
-{% for post in posts>
+{% for post in posts %}
   <article>
     <header>{{ post.title }}</header>
     <section>{{ post.text }}</section>
@@ -50,23 +50,23 @@ Now, when rendering the child template, the loop is going to use the block defin
 Let's take another example: a block included within an **if** statement:
 
 ```canvas
-{% if posts is empty>
-  {% block head>
+{% if posts is empty %}
+  {% block head %}
     {{ parent() }}
 
     <meta name="robots" content="noindex, follow">
-  {% endblock head>
+  {% endblock head %}
 {% endif %}
 ```
 
 Contrary to what you might think, this template does not define a block conditionally; it just makes overridable by a child template the output of what will be rendered when the condition is `true`. If you want the output to be displayed conditionally, use the following instead:
 
 ```canvas
-{% block head>
+{% block head %}
   {{ parent() }}
 
-  {% if posts is empty>
+  {% if posts is empty %}
     <meta name="robots" content="noindex, follow">
   {% endif %}
-{% endblock head>
+{% endblock head %}
 ```

--- a/content/docs/canvas/tags/deprecated.md
+++ b/content/docs/canvas/tags/deprecated.md
@@ -6,19 +6,19 @@ This page is generally useful to Canvas template developers. Canvas generates a 
 
 ```canvas
 {# base.html #}
-{% deprecated 'The "base.html" template is deprecated, use "layout.html" instead.>
+{% deprecated 'The "base.html" template is deprecated, use "layout.html" instead.' %}
 {% extends 'layout.html' %}
 ```
 
 Also you can deprecate a block in the following way:
 
 ```canvas
-{% block hey>
+{% block hey %}
   {% deprecated 'The "hey" block is deprecated, use "greet" instead.' %}
   {{ block('greet') }}
 {% endblock %}
 
-{% block greet>
+{% block greet %}
   Hey you!
 {% endblock %}
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This PR fixes Canvas template syntax errors.