### PR TITLE
fix: courier install docs for windows

### DIFF
--- a/content/docs/courier/installation/meta.json
+++ b/content/docs/courier/installation/meta.json
@@ -3,6 +3,7 @@
     "macos",
     "windows",
     "linux",
-    "!create-courier-token"
+    "!create-courier-token",
+    "!windows-token-setup"
   ]
 }

--- a/content/docs/courier/installation/windows-token-setup.mdx
+++ b/content/docs/courier/installation/windows-token-setup.mdx
@@ -1,0 +1,30 @@
+---
+title: Create Courier token for Windows
+---
+
+Before using **Courier**, you need to generate a Blutui access token. Follow these steps:
+
+1. In your [Agency Console](https://console.blutui.com), click on your avatar in the top-right corner and choose `Edit my profile`.
+2. Go to the `Apps` section in the sidebar.
+3. Click `Create token` on the right, under the "Access tokens" section.
+4. Name your token, e.g., "Work Laptop".
+5. Set the token type to "Courier". Required permissions for Courier will be automatically selected.
+6. Click **Create token**. Your Courier token will be displayed. Copy and store it securely, as it will only be shown this one time.
+
+### Using your Courier token
+
+1. Create a new `token.txt` file with your access token.
+
+2. Log in to Courier using your token file:
+
+```powershell
+courier login --token (Get-Content token.txt)
+```
+
+3. Remember to delete the `token.txt` file once you have successfully logged into Courier.
+
+Once configured, you're ready to start pushing and pulling projects.
+
+<Callout>
+Complete the [getting started guide](/docs/courier/getting-started#linking-your-project) and learn how to start building your first project.
+</Callout>

--- a/content/docs/courier/installation/windows-token-setup.mdx
+++ b/content/docs/courier/installation/windows-token-setup.mdx
@@ -18,7 +18,7 @@ Before using **Courier**, you need to generate a Blutui access token. Follow the
 2. Log in to Courier using your token file:
 
 ```powershell
-courier login --token (Get-Content token.txt)
+Get-Content token.txt -Raw | courier login --token
 ```
 
 3. Remember to delete the `token.txt` file once you have successfully logged into Courier.

--- a/content/docs/courier/installation/windows.mdx
+++ b/content/docs/courier/installation/windows.mdx
@@ -13,6 +13,10 @@ scoop install blutui/courier
 Git is required to install **scoop** buckets
 </Callout>
 
+## Create a Courier token
+
+<include>./windows-token-setup.mdx</include>
+
 ## Upgrade on Windows
 
 To upgrade to the latest version of `courier`, run:
@@ -20,7 +24,3 @@ To upgrade to the latest version of `courier`, run:
 ```bash
 scoop update courier
 ```
-
-## Create a Courier token
-
-<include>./windows-token-setup.mdx</include>

--- a/content/docs/courier/installation/windows.mdx
+++ b/content/docs/courier/installation/windows.mdx
@@ -13,10 +13,6 @@ scoop install blutui/courier
 Git is required to install **scoop** buckets
 </Callout>
 
-## Create a Courier token
-
-<include>./create-courier-token.mdx</include>
-
 ## Upgrade on Windows
 
 To upgrade to the latest version of `courier`, run:
@@ -24,3 +20,7 @@ To upgrade to the latest version of `courier`, run:
 ```bash
 scoop update courier
 ```
+
+## Create a Courier token
+
+<include>./windows-token-setup.mdx</include>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! First you must fill out some information below before we can review this pull request, by explaining why you're making a change (or linking to an issue) and what changes you've made.
-->

This pull request updates the Courier installation documentation for Windows to provide a more tailored and clear guide for generating and using Courier tokens. The main improvement is the addition of a Windows-specific token setup guide and its integration into the installation flow.

**Documentation improvements:**

* Added a new file, `windows-token-setup.mdx`, containing step-by-step instructions for creating and using a Courier token on Windows, including PowerShell usage and security reminders.
* Updated `windows.mdx` to include the new `windows-token-setup.mdx` guide instead of the generic token creation instructions, ensuring Windows users receive relevant guidance.

**Meta and navigation updates:**

* Updated `meta.json` to reference the new `!windows-token-setup` page, ensuring it is properly indexed and available in navigation.